### PR TITLE
corrected activity editing logic and intl edge cases

### DIFF
--- a/src/components/ActivitiesListItem/ActivitiesListItem.js
+++ b/src/components/ActivitiesListItem/ActivitiesListItem.js
@@ -30,9 +30,9 @@ const ActivityDesc = styled.p`
 const ActivitiesListItem = ({ activity: { name, activityOrdinal, teacher, id, room } }) => (
   <>
     <ActivityOrdinalWrapper>{`${activityOrdinal}.`}</ActivityOrdinalWrapper>
-    <FormattedMessage data-test="react-link" id="planView.activityName" defaultMessage={name}>
-      {value => <EditActivityLink to={EDIT_ACTIVITY_ROUTE(id)}>{value}</EditActivityLink>}
-    </FormattedMessage>
+    <EditActivityLink data-test="react-link" to={EDIT_ACTIVITY_ROUTE(id)}>
+      {name}
+    </EditActivityLink>
     <ActivityDesc>
       <FormattedMessage
         id="planView.activityDetails"

--- a/src/components/ActivitiesListItem/ActivitiesListItem.test.js
+++ b/src/components/ActivitiesListItem/ActivitiesListItem.test.js
@@ -16,7 +16,7 @@ describe('ActivitiesListItem', () => {
     );
     const { name, teacher, room } = testState.activities.items[3];
     expect(wrapper.find('[data-test="react-link"]').exists()).toBe(true);
-    expect(wrapper.find('[data-test="react-link"]').text()).toBe(name);
+    expect(wrapper.find('a[data-test="react-link"]').text()).toBe(name);
     expect(wrapper.find('[data-test="activity-details"]').text()).toBe(
       `Teacher: ${teacher}, in room: ${room}`,
     );

--- a/src/components/ActivityForm/ActivityForm.js
+++ b/src/components/ActivityForm/ActivityForm.js
@@ -46,6 +46,8 @@ export default class ActivityForm extends React.Component {
     super(props);
     this.state = {
       currentActivities: props.currentActivities,
+      editedActivityDay: props.activity.day,
+      editedActivityOrdinal: props.activity.activityOrdinal,
       activityOrdinal: props.activity.activityOrdinal,
       day: props.activity.day,
       name: props.activity.name,
@@ -91,31 +93,51 @@ export default class ActivityForm extends React.Component {
       roomError: '',
       teacherError: '',
     });
-    const { name, day, activityOrdinal, room, teacher, currentActivities } = this.state;
+    const {
+      name,
+      day,
+      activityOrdinal,
+      room,
+      teacher,
+      currentActivities,
+      editedActivityDay,
+      editedActivityOrdinal,
+    } = this.state;
     const errors = {};
-    const errorMsg = 'form.error.required';
+    const errorMsgRequired = 'form.error.required';
+    const errorMsgOccupied = 'form.error.occupied';
     if (
       !name ||
       !day ||
       !activityOrdinal ||
       !teacher ||
       !room ||
-      !validateFreeTimeSlot({ day, activityOrdinal }, currentActivities)
+      !validateFreeTimeSlot(
+        { day, activityOrdinal },
+        { editedActivityDay, editedActivityOrdinal },
+        currentActivities,
+      )
     ) {
       if (!name) {
-        errors.nameError = errorMsg;
+        errors.nameError = errorMsgRequired;
       }
       if (!activityOrdinal) {
-        errors.activityOrdinalError = errorMsg;
+        errors.activityOrdinalError = errorMsgRequired;
       }
       if (!room) {
-        errors.roomError = errorMsg;
+        errors.roomError = errorMsgRequired;
       }
       if (!teacher) {
-        errors.teacherError = errorMsg;
+        errors.teacherError = errorMsgRequired;
       }
-      if (!validateFreeTimeSlot({ day, activityOrdinal }, currentActivities)) {
-        errors.activityOrdinalError = 'form.error.occupied';
+      if (
+        !validateFreeTimeSlot(
+          { day, activityOrdinal },
+          { editedActivityDay, editedActivityOrdinal },
+          currentActivities,
+        )
+      ) {
+        errors.activityOrdinalError = errorMsgOccupied;
       }
       if (!_.isEmpty(errors)) {
         this.setState(errors);

--- a/src/components/EditActivityPage/EditActivityPage.js
+++ b/src/components/EditActivityPage/EditActivityPage.js
@@ -130,8 +130,5 @@ export default connect(
   mapDispatchToProps,
 )(EditActivityPage);
 
-// TODO: I recommend you to think about react-intl package.
-// This is not a priority, but it would be great knowledge for future ;)
-// spend some time for internatiolization in short future.
 // TODO: not for this pr, but can we change this function name to normal one ?
 // why not removeActivity?

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -68,9 +68,3 @@ const Header = () => (
 );
 
 export default Header;
-
-// TODO: why do you need to wrap it with styled with empty block?
-// Karols comment: there was an imported component, wrapped in other 'styled' component,
-// but without anything in ``. Karols comment ends.
-// I think, that there is a lack of some rules in your eslint setup
-// for styled-comopnents (handle it by separate PR)

--- a/src/components/elements/Input/Input.js
+++ b/src/components/elements/Input/Input.js
@@ -36,9 +36,14 @@ const StyledInput = styled.input`
 const Input = ({ type, placeholder, value, onChange, onBlur, errorMsg }) => (
   <>
     <DescriptionsWrapper>
-      <Description>
-        <FormattedMessage id={`activity.${camelCase(placeholder)}`} defaultMessage={placeholder} />
-      </Description>
+      {placeholder && (
+        <Description>
+          <FormattedMessage
+            id={`activity.${camelCase(placeholder)}`}
+            defaultMessage={placeholder}
+          />
+        </Description>
+      )}
       {errorMsg && (
         <Description error>
           <FormattedMessage id={errorMsg} defaultMessage={errorMsg} data-test="error-message" />
@@ -46,7 +51,7 @@ const Input = ({ type, placeholder, value, onChange, onBlur, errorMsg }) => (
       )}
     </DescriptionsWrapper>
     <FormattedMessage
-      id={`activity.${camelCase(placeholder)}`}
+      id={placeholder ? `activity.${camelCase(placeholder)}` : 'form.input.defaultPlaceholder'}
       defaultMessage={placeholder}
       data-test="input"
     >

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -6,7 +6,10 @@ export const validatePositive = input => {
   return Number(input) > 0;
 };
 
-export const validateFreeTimeSlot = (activity, currentActivities) =>
-  !currentActivities.some(
-    item => item.day === activity.day && item.activityOrdinal === activity.activityOrdinal,
-  );
+export const validateFreeTimeSlot = (
+  { day, activityOrdinal },
+  { editedActivityDay, editedActivityOrdinal },
+  currentActivities,
+) =>
+  (day === editedActivityDay && activityOrdinal === editedActivityOrdinal) ||
+  !currentActivities.some(item => item.day === day && item.activityOrdinal === activityOrdinal);

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -31,6 +31,9 @@
       "required": "Required!",
       "occupied": "This time slot is already occupied!"
     },
+    "input": {
+      "defaultPlaceholder": "Type text"
+    },
     "activityFormSelectDefault": "Pick a day"
   }
 }

--- a/src/translations/pl.json
+++ b/src/translations/pl.json
@@ -31,6 +31,9 @@
       "required": "Pole wymagane!",
       "occupied": "Ta lekcja jest już zajęta!"
     },
+    "input": {
+      "defaultPlaceholder": "Wprowadź text"
+    },
     "activityFormSelectDefault": "Wybierz dzień"
   }
 }


### PR DESCRIPTION
Bug: free "time slot" validation for edition of activities was TOO good and did not allow editing activities at all, throwing that 'This time slot is occupied!', which wast totally true. -> Fixed that
Bug: many warnings from intl in console -> Fixed that